### PR TITLE
Allow ssh:// git repos

### DIFF
--- a/bin/match
+++ b/bin/match
@@ -10,7 +10,7 @@ HighLine.track_eof = false
 class MatchApplication
   include Commander::Methods
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def run
     program :version, Match::VERSION
     program :description, Match::DESCRIPTION
@@ -93,7 +93,7 @@ class MatchApplication
 
     run!
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 end
 
 begin

--- a/lib/match/options.rb
+++ b/lib/match/options.rb
@@ -14,8 +14,8 @@ module Match
                                      optional: false,
                                      short_option: "-r",
                                      verify_block: proc do |value|
-                                       unless value.start_with?("https://") || value.start_with?("git")
-                                         raise "git_url must start with either https:// or git://".red
+                                       unless value.match("^(https|git|ssh)://")
+                                         raise "git_url must start with https://, git:// or ssh://".red
                                        end
                                      end),
         FastlaneCore::ConfigItem.new(key: :type,


### PR DESCRIPTION
Our private git repo runs using the ssh protocol — but I'd still like to use match!
