### PR TITLE
replaced ugly 'if' conditions with a 'case' block

### DIFF
--- a/lib/match/generator.rb
+++ b/lib/match/generator.rb
@@ -57,11 +57,18 @@ module Match
 
     # @return the name of the provisioning profile type
     def self.profile_type_name(type)
-      return "Development" if type == :development
-      return "AdHoc" if type == :adhoc
-      return "AppStore" if type == :appstore
-      return "InHouse" if type == :enterprise
-      return "Unkown"
+      case type
+      when :development
+        "Development"
+      when :adhoc
+        "AdHoc"
+      when :appstore
+        "AppStore"
+      when :enterprise
+        "InHouse"
+      else
+        "Unknown"
+      end
     end
   end
 end


### PR DESCRIPTION
A method was using multiple 'if' conditions (not even `if/elsif/end`) to return a string value based on what symbol argument was being passed to the method. This has now been changed so that only 1 `case` block is used which is easier on the eyes and easier to modify/maintain.

Redundant `return` keywords are also removed from the method.
