### PR TITLE
Allow git@github.com:USER/REPO.git urls again

### DIFF
--- a/lib/match/options.rb
+++ b/lib/match/options.rb
@@ -14,8 +14,8 @@ module Match
                                      optional: false,
                                      short_option: "-r",
                                      verify_block: proc do |value|
-                                       unless value.match("^(https|git|ssh)://")
-                                         raise "git_url must start with https://, git:// or ssh://".red
+                                       unless value.match("^(https|ssh)://") || value.start_with?("git")
+                                         raise "git_url must start with https://, ssh:// or git".red
                                        end
                                      end),
         FastlaneCore::ConfigItem.new(key: :type,


### PR DESCRIPTION
Hi Felix and thanks so much for making our lives so much easier with all the fastlane tools! 🚀

This pull request restores support for cloning git@github.com:USER/REPO.git urls which
I believe was accidentially removed in #11.

I can confirm that this worked in 0.1.0, broke in 0.1.1 and works with this pull again.
