### PR TITLE
Fixed a wrong certificate type in enterprise+appstore environment

### DIFF
--- a/lib/match.rb
+++ b/lib/match.rb
@@ -22,6 +22,7 @@ module Match
   def self.environments
     envs = %w(appstore adhoc development)
     envs << "enterprise" if ENV["MATCH_FORCE_ENTERPRISE"]
+    envs << "enterprise_development" if ENV["MATCH_FORCE_ENTERPRISE"]
     return envs
   end
 end

--- a/lib/match.rb
+++ b/lib/match.rb
@@ -22,7 +22,6 @@ module Match
   def self.environments
     envs = %w(appstore adhoc development)
     envs << "enterprise" if ENV["MATCH_FORCE_ENTERPRISE"]
-    envs << "enterprise_development" if ENV["MATCH_FORCE_ENTERPRISE"]
     return envs
   end
 end

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -38,7 +38,7 @@ module Match
     def certificate(params: nil)
       cert_type = :distribution
       cert_type = :development if params[:type] == "development"
-      cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && Spaceship.client.in_house?
+      cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && Spaceship.client.in_house? && params[:type] == "enterprise"
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -38,7 +38,7 @@ module Match
     def certificate(params: nil)
       cert_type = :distribution
       cert_type = :development if params[:type] == "development"
-      cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && Spaceship.client.in_house? && params[:type] == "enterprise"
+      cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && params[:type] == "enterprise"
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -38,6 +38,7 @@ module Match
     def certificate(params: nil)
       cert_type = :distribution
       cert_type = :development if params[:type] == "development"
+      cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && Spaceship.client.in_house?
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -47,8 +47,7 @@ module Match
       if certs.count == 0 or keys.count == 0
         UI.important "Couldn't find a valid code signing identity in the git repo for #{cert_type}... creating one for you now"
         UI.crash!("No code signing identity found and can not create a new one because you enabled `readonly`") if params[:readonly]
-        cert_path = Generator.generate_certificate(params, (cert_type == :development_enterprise ? :development : cert_type))
-
+        cert_path = Generator.generate_certificate(params, cert_type)
         self.changes_to_commit = true
       else
         cert_path = certs.last

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -47,7 +47,8 @@ module Match
       if certs.count == 0 or keys.count == 0
         UI.important "Couldn't find a valid code signing identity in the git repo for #{cert_type}... creating one for you now"
         UI.crash!("No code signing identity found and can not create a new one because you enabled `readonly`") if params[:readonly]
-        cert_path = Generator.generate_certificate(params, cert_type)
+        cert_path = Generator.generate_certificate(params, (cert_type == :development_enterprise ? :development : cert_type))
+
         self.changes_to_commit = true
       else
         cert_path = certs.last

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -38,7 +38,6 @@ module Match
     def certificate(params: nil)
       cert_type = :distribution
       cert_type = :development if params[:type] == "development"
-      cert_type = :development_enterprise if (ENV["MATCH_FORCE_ENTERPRISE"] && params[:type] == "enterprise_development")
       cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && params[:type] == "enterprise"
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -38,6 +38,7 @@ module Match
     def certificate(params: nil)
       cert_type = :distribution
       cert_type = :development if params[:type] == "development"
+      cert_type = :development_enterprise if (ENV["MATCH_FORCE_ENTERPRISE"] && params[:type] == "enterprise_development")
       cert_type = :enterprise if ENV["MATCH_FORCE_ENTERPRISE"] && params[:type] == "enterprise"
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]


### PR DESCRIPTION
Fix an issue where match would take the distribution certificate instead of the enterprise one in force enterprise environment.
