### PR TITLE
This should address the issues described in [https://github.com/fastlane/match/issues/42]

### DIFF
--- a/lib/match/change_password.rb
+++ b/lib/match/change_password.rb
@@ -2,6 +2,7 @@ module Match
   class ChangePassword
     def self.update(params: nil, from: nil, to: nil)
       to ||= ChangePassword.ask_password("New passphrase for Git Repo: ")
+      from ||= ChangePassword.ask_password("Old passphrase for Git Repo: ")
       GitHelper.clear_changes
       workspace = GitHelper.clone(params[:git_url], params[:shallow_clone], manual_password: from)
       Encrypt.new.clear_password(params[:git_url])
@@ -12,8 +13,8 @@ module Match
     end
 
     def self.ask_password(msg = "Passphrase for Git Repo: ")
-      password = ""
-      while password.to_s.length == 0
+      password = nil
+      while password == nil
         password = ask(msg.yellow) { |q| q.echo = "*" }
         password2 = ask("Type passphrase again: ".yellow) { |q| q.echo = "*" }
         if password != password2

--- a/lib/match/encrypt.rb
+++ b/lib/match/encrypt.rb
@@ -71,7 +71,7 @@ module Match
     end
 
     def crypt(path: nil, password: nil, encrypt: true)
-      if password.to_s.strip.length == 0
+      if password.to_s.strip.length == 0 && encrypt
         UI.user_error!("No password supplied")
       end
 


### PR DESCRIPTION
When fixing [https://github.com/fastlane/match/issues/36] I supplied a check in the crypt method, that a password may not be empty. That was fatal for the case, when you wanted to change your password and the former password was empty.  
I modified this now and the user will be warned only when an empty password was supplied for **encryption**. **Decryption will now accept an empty password**. This addresses the issues in [https://github.com/fastlane/match/issues/42].

When changing passwords, the update method asks only for the new password. And since no empty password could be supplied - as mentioned above, the password could not be changed.
I modified the update method slightly to ask not only for the new, but also for the old password. This might be a pain when a correct password was used earlier and it is stored in the keychain. But, for the case when no password was used for en- and decryption, this might be the only way to change your repo-password.
