### PR TITLE
Issue #59

### DIFF
--- a/lib/match/generator.rb
+++ b/lib/match/generator.rb
@@ -35,7 +35,8 @@ module Match
     def self.generate_provisioning_profile(params: nil, prov_type: nil, certificate_id: nil)
       require 'sigh'
 
-      prov_type = :enterprise if Match.enterprise? && ENV["SIGH_PROFILE_ENTERPRISE"]
+      prov_type = :enterprise if Match.enterprise? && ENV["SIGH_PROFILE_ENTERPRISE"] && !params[:type] == "development"
+      
       profile_name = ["match", profile_type_name(prov_type), params[:app_identifier]].join(" ")
 
       arguments = FastlaneCore::Configuration.create(Sigh::Options.available_options, {

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -68,10 +68,10 @@ module Match
 
     def profile(params: nil, certificate_id: nil)
       prov_type = params[:type].to_sym
-
-      profile_name = [prov_type.to_s, params[:app_identifier]].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
+      
+      profile_name = [Match::Generator.profile_type_name(prov_type), params[:app_identifier]].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
       profiles = Dir[File.join(params[:workspace], "profiles", prov_type.to_s, "#{profile_name}.mobileprovision")]
-
+      
       # Install the provisioning profiles
       profile = profiles.last
       if profile.nil? or params[:force]


### PR DESCRIPTION
Fix a naming issue with enterprise provisioning profiles that caused match to always recreate profiles for enterprise accounts