### PR TITLE
Fixed recreation loop of enterprise profiles by fixing the profile name to use the generator type name

### DIFF
--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -69,7 +69,8 @@ module Match
     def profile(params: nil, certificate_id: nil)
       prov_type = params[:type].to_sym
 
-      profile_name = [prov_type.to_s, params[:app_identifier]].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
+      profile_name = [Match::Generator.profile_type_name(prov_type), params[:app_identifier]].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
+
       profiles = Dir[File.join(params[:workspace], "profiles", prov_type.to_s, "#{profile_name}.mobileprovision")]
 
       # Install the provisioning profiles


### PR DESCRIPTION
I got an error when using an enterprise account and readonly. Match couldn't find the previously created provisioning profile. I found out that match generated `enterprise_app.identifier.mobileprovision` instead of `InHouse_app.identifier.mobileprovision`
