### PR TITLE
Add force_for_new_devices option to renew profile if device count differs

### DIFF
--- a/lib/match/options.rb
+++ b/lib/match/options.rb
@@ -91,7 +91,12 @@ module Match
                                          end
                                        end
                                      end,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :force_for_new_devices,
+                                     env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
+                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed",
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -74,6 +74,8 @@ module Match
 
       # Install the provisioning profiles
       profile = profiles.last
+      params[:force] = is_device_count_different(params: params, profile: profile) if params[:force] == false
+
       if profile.nil? or params[:force]
         UI.crash!("No matching provisioning profiles found and can not create a new one because you enabled `readonly`") if params[:readonly]
         profile = Generator.generate_provisioning_profile(params: params,
@@ -89,6 +91,20 @@ module Match
       Utils.fill_environment(params, uuid)
 
       return uuid
+    end
+
+    def is_device_count_different(params: nil, profile: nil)
+      if profile and params[:force_for_new_devices]
+        parsed = FastlaneCore::ProvisioningProfile.parse(profile)
+        uuid = parsed["UUID"]
+
+        portal_profiles = Spaceship.provisioning_profile.ad_hoc.find_by_bundle_id(params[:app_identifier])
+        portal_profile = portal_profiles.find { |i| i.uuid == uuid }
+        profile_device_count = portal_profile.devices.count
+        portal_device_count = Spaceship.device.all.count
+
+        return portal_device_count != profile_device_count
+      end
     end
   end
 end


### PR DESCRIPTION
Quick background: I work on an iOS project that contains 16 targets each with their own Watch App and Watch Extension. Managing these manually across seven team members before match was truly a nightmare. Thankfully things are simplified now but there was one problem: what if someone added a new device? I could add the --force flag to every match call in my Fastfile but that seems unnecessary and would cause my repository to grow to a size thats progressively slower to clone (we use Stash so no shallow_clone for us).

Enter the --force_for_new_devices flag. The idea is match will compare the number of devices in your provisioning profile to the number of registered devices on the developer portal and, if they differ, set the --force flag. So now anytime new devices are added, as long as you have this flag passed to match, everything will take care of itself and I won't have to edit my Jenkins configuration.

Let me know what you think. I'm pretty new to Ruby so I apologize if I used methods or styles that are odd. I am open to any and all feedback!
