### PR TITLE
Add force_for_new_devices option to renew profile if device count differs

### DIFF
--- a/lib/match/options.rb
+++ b/lib/match/options.rb
@@ -91,7 +91,12 @@ module Match
                                          end
                                        end
                                      end,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :force_for_new_devices,
+                                     env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
+                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed",
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -58,6 +58,10 @@ describe Match do
       expect(spaceship).to receive(:profile_exists).and_return(true)
       expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
 
+      profiles = "profiles"
+      expect(Spaceship).to receive(:provisioning_profile).and_return(profiles)
+      expect(profiles).to receive(:all).and_return([])
+
       Match::Runner.new.run(config)
     end
   end


### PR DESCRIPTION
Quick background: I work on an iOS project that contains 16 targets each with their own Watch App and Watch Extension. Managing these manually across seven team members before match was truly a nightmare. Thankfully things are simplified now but there was one problem: what if someone added a new device? I could add the --force flag to every match call in my Fastfile but that seems unnecessary and would cause my repository to grow to a size thats progressively slower to clone (we use Stash so no shallow_clone for us).

Enter the --force_for_new_devices flag. The idea is match will compare the number of devices in your provisioning profile to the number of registered devices on the developer portal and, if they differ, set the --force flag. So now anytime new devices are added, as long as you have this flag passed to match, everything will take care of itself and I won't have to edit my Jenkins configuration.

Let me know what you think. I'm pretty new to Ruby so I apologize if I used methods or styles that are odd. I am open to any and all feedback!
