### PR TITLE
Respect force_for_new_devices flag

### DIFF
--- a/lib/match/runner.rb
+++ b/lib/match/runner.rb
@@ -74,7 +74,10 @@ module Match
 
       # Install the provisioning profiles
       profile = profiles.last
-      params[:force] = device_count_different?(profile: profile) unless params[:force]
+
+      if params[:force_for_new_devices]
+        params[:force] = device_count_different?(profile: profile) unless params[:force]
+      end
 
       if profile.nil? or params[:force]
         UI.crash!("No matching provisioning profiles found and can not create a new one because you enabled `readonly`") if params[:readonly]

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -58,10 +58,6 @@ describe Match do
       expect(spaceship).to receive(:profile_exists).and_return(true)
       expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
 
-      profiles = "profiles"
-      expect(Spaceship).to receive(:provisioning_profile).and_return(profiles)
-      expect(profiles).to receive(:all).and_return([])
-
       Match::Runner.new.run(config)
     end
   end


### PR DESCRIPTION
See previous pull request ( #102 ) for original idea and implementation.

This got missed in my commits to the original pull request and has the codebase actually respect the force_for_new_devices flag. Without the "if" check in this pull request, we essentially make the default for the new flag true. This corrects that error. Sorry for the miss. :disappointed: 

Tested by enabling and disabling devices in the developer portal, which essentially removes them from the available pool of devices for provisioning profiles. Rspec ran all tests without failures, and rubocop -a (0.35.1) found no issues. 