### PR TITLE
Reverse the default value of :shallow_clone to be false

### DIFF
--- a/lib/match/options.rb
+++ b/lib/match/options.rb
@@ -79,7 +79,7 @@ module Match
                                      env_name: "MATCH_SHALLOW_CLONE",
                                      description: "Make a shallow clone of the repository (truncate the history to 1 revision)",
                                      is_string: false,
-                                     default_value: true),
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :workspace,
                                      description: nil,
                                      verify_block: proc do |value|

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -5,7 +5,8 @@ describe Match do
       values = {
         app_identifier: "tools.fastlane.app",
         type: "appstore",
-        git_url: git_url
+        git_url: git_url,
+        shallow_clone: true
       }
 
       config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
@@ -44,7 +45,7 @@ describe Match do
       key_path = "./spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
       keychain = "login.keychain"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 


### PR DESCRIPTION
There have been a number of reports that doing a shallow clone in git leaves match unable to push changes back to the remote repository. This manifests as a fatal error in match saying, `protocol error: expected old/new/ref, got 'shallow xxxxxx'`.

Because shallow cloning is an optimization that is causing problems for some users, I think it is best if we reverse the current default value for this option to be off, to fix possible problems, but allow opt-in for the optimizations.

This should be backwards-compatible in that folks who are not specifying a value for shallow_clone will stop getting shallow clones, but continue to work.
